### PR TITLE
Add normalization for multiple licenses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-license"
 description = "Cargo subcommand to see license of dependencies"
 authors = ["Onur Aslan <onur@onur.im>"]
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,28 @@ impl Dependency {
             .unwrap_or(Err(human("PKG download error")))
     }
 
+    fn normalize(&self, license_string: &Option<String>) -> Option<String> {
+        match license_string {
+            &None => None,
+            &Some(ref license) => {
+                let mut list : Vec<&str> = license.split('/').collect();
+                for elem in list.iter_mut() {
+                    *elem = elem.trim();
+                }
+                list.sort();
+                list.dedup();
+                Some(list.join(" / "))
+            }
+        }
+    }
+
     pub fn get_license(&self) -> String {
         // FIXME: So many N/A's
         if !self.source.starts_with("registry") {
             "N/A".to_owned()
         } else {
             match self.get_cargo_package() {
-                Ok(pkg) => pkg.manifest().metadata().license.clone().unwrap_or("N/A".to_owned()),
+                Ok(pkg) => self.normalize(&pkg.manifest().metadata().license).unwrap_or("N/A".to_owned()),
                 Err(_) => "N/A".to_owned(),
             }
         }


### PR DESCRIPTION
This takes a string like "MIT/Apache-2.0", splits it into the component
licenses "MIT" and "Apache-2.0", sorts them, and recombines them back into
"Apache-2.0/MIT". This normalization properly groups different packages which
have effectively the same license but word them differently.