### PR TITLE
Add option to display one crate per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,19 @@ A cargo subcommand to see license of dependencies.
 ## Installation and Usage
 
 You can install cargo-license with: `cargo install cargo-license` and
-run it in your project directory with: `cargo license`.
+run it in your project directory with: `cargo license` or `cargo-license`.
+
+```
+Usage: cargo-license [options]
+
+Options:
+    -a, --authors       Display crate authors
+    -d, --do-not-bundle 
+                        Output one license per line.
+    -h, --help          print this help menu
+
+```
+
 
 
 ## Example

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -71,18 +71,28 @@ fn one_license_per_line(dependencies: Vec<cargo_license::Dependency>, display_au
 
 }
 
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {} [options]", program);
+    print!("{}", opts.usage(&brief));
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let mut opts = Options::new();
-    opts.optflag("", "authors", "Display crate authors");
-    opts.optflag("", "do-not-bundle", "Output one license per line.");
+    let program = args[0].clone();
+    opts.optflag("a", "authors", "Display crate authors");
+    opts.optflag("d", "do-not-bundle", "Output one license per line.");
+    opts.optflag("h", "help", "print this help menu");
+
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(err) => {
-            println!("Usage: {} [--authors] [--do-not-bundle]\n{}", args[0], err);
-            std::process::exit(1);
-        }
+        Err(f) => { print_usage(&program, opts); 
+            panic!(f.to_string()) }
     };
+    if matches.opt_present("h") {
+        print_usage(&program, opts);
+        return;
+    }
 
     let display_authors = matches.opt_present("authors");
     let do_not_bundle = matches.opt_present("do-not-bundle");
@@ -96,7 +106,6 @@ fn main() {
     };
 
     if do_not_bundle {
-        println!("do_not_bundle");
         one_license_per_line(dependencies, display_authors);
     } else {
         group_by_license_type(dependencies, display_authors);

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -10,21 +10,7 @@ use std::collections::BTreeSet;
 use std::collections::btree_map::Entry::*;
 use ansi_term::Colour::Green;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    let mut opts = Options::new();
-    opts.optflag("", "authors", "Display crate authors");
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(err) => {
-            println!("Usage: {} [--authors]\n{}", args[0], err);
-            std::process::exit(1);
-        }
-    };
-
-    let display_authors = matches.opt_present("authors");
-
-    let dependencies = cargo_license::get_dependencies_from_cargo_lock().unwrap();
+fn group_by_license_type(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
 
     let mut table: BTreeMap<String, Vec<cargo_license::Dependency>> = BTreeMap::new();
 
@@ -39,7 +25,10 @@ fn main() {
     for (license, crates) in table {
         let crate_names = crates.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
         if display_authors {
-            let crate_authors = crates.iter().flat_map(|c| c.get_authors().unwrap_or(vec![])).collect::<BTreeSet<_>>();
+            let crate_authors = crates
+                    .iter()
+                    .flat_map(|c| c.get_authors().unwrap_or(vec![]))
+                    .collect::<BTreeSet<_>>();
             println!("{} ({})\n{}\n{} {}",
                      Green.bold().paint(license),
                      crates.len(),
@@ -53,4 +42,64 @@ fn main() {
                      crate_names.join(", "));
         }
     }
+}
+
+fn one_license_per_line(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
+
+    for dependency in dependencies {
+        let name = dependency.name.clone();
+        let version = dependency.version.clone();
+        let license = dependency.get_license().unwrap_or("N/A".to_owned());
+        let source = dependency.source.clone();
+        if display_authors {
+            let authors = dependency.get_authors().unwrap_or(vec![]);
+            println!("{}: {}, \"{}\", {}, {} \"{}\"",
+                     Green.bold().paint(name),
+                     version,
+                     license,
+                     source,
+                     Green.paint("by"),
+                     authors.into_iter().collect::<Vec<_>>().join(", "));
+        } else {
+            println!("{}: {}, \"{}\", {}",
+                     Green.bold().paint(name),
+                     version,
+                     license,
+                     source);
+        }
+    };
+
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut opts = Options::new();
+    opts.optflag("", "authors", "Display crate authors");
+    opts.optflag("", "do-not-bundle", "Output one license per line.");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(err) => {
+            println!("Usage: {} [--authors] [--do-not-bundle]\n{}", args[0], err);
+            std::process::exit(1);
+        }
+    };
+
+    let display_authors = matches.opt_present("authors");
+    let do_not_bundle = matches.opt_present("do-not-bundle");
+
+    let dependencies = match cargo_license::get_dependencies_from_cargo_lock() {
+        Ok(m) => m,
+        Err(err) => {
+            println!("Cargo.lock file not found. Try building the project first.\n{}", err);
+            std::process::exit(1);
+        }
+    };
+
+    if do_not_bundle {
+        println!("do_not_bundle");
+        one_license_per_line(dependencies, display_authors);
+    } else {
+        group_by_license_type(dependencies, display_authors);
+    }
+
 }


### PR DESCRIPTION
I found that bundling the licenses together by type wasn't always ideal. This PR give an option to display info about each crate individually.  An example of the output is:
```
$ cargo-license --do-not-bundle 
advapi32-sys: 0.2.0, "MIT", registry+https://github.com/rust-lang/crates.io-index
aho-corasick: 0.6.3, "MIT/Unlicense", registry+https://github.com/rust-lang/crates.io-index
ansi_term: 0.9.0, "MIT", registry+https://github.com/rust-lang/crates.io-index
backtrace: 0.3.3, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index
backtrace-sys: 0.1.16, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index
bitflags: 0.7.0, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index
bitflags: 0.9.1, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index
cargo: 0.19.0, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index
```

and with authors:

```
$ cargo-license --do-not-bundle --authors
advapi32-sys: 0.2.0, "MIT", registry+https://github.com/rust-lang/crates.io-index, by "Peter Atashian <retep998@gmail.com>"
aho-corasick: 0.6.3, "MIT/Unlicense", registry+https://github.com/rust-lang/crates.io-index, by "Andrew Gallant <jamslam@gmail.com>"
ansi_term: 0.9.0, "MIT", registry+https://github.com/rust-lang/crates.io-index, by "ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>"
backtrace: 0.3.3, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "Alex Crichton <alex@alexcrichton.com>, The Rust Project Developers"
backtrace-sys: 0.1.16, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "Alex Crichton <alex@alexcrichton.com>"
bitflags: 0.7.0, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "The Rust Project Developers"
bitflags: 0.9.1, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "The Rust Project Developers"
cargo: 0.19.0, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "Yehuda Katz <wycats@gmail.com>, Carl Lerche <me@carllerche.com>, Alex Crichton <alex@alexcrichton.com>"
cc: 1.0.1, "Apache-2.0/MIT", registry+https://github.com/rust-lang/crates.io-index, by "Alex Crichton <alex@alexcrichton.com>"
```

new usage is:

```
Usage: cargo-license [options]

Options:
    -a, --authors       Display crate authors
    -d, --do-not-bundle 
                        Output one license per line.
    -h, --help          print this help menu

```



