### PR TITLE
Add support for full license summary.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-license"
 description = "Cargo subcommand to see license of dependencies"
 authors = ["Onur Aslan <onur@onur.im>"]
-version = "0.1.5"
+version = "0.1.6"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -11,11 +11,14 @@ use ansi_term::Colour::Green;
 
 fn print_full_licenses(dependencies: Vec<cargo_license::Dependency>) {
     for dependency in dependencies {
+        println!("{}:", dependency.name);
         if let Some(licenses) = dependency.get_license_text() {
-            println!("{}:", dependency.name);
             for license in licenses {
                 println!("{}", license);
             }
+        } else {
+            let license = dependency.get_license().unwrap_or("N/A".to_owned());
+            println!("Could not find license file. License(s) specified in crate: {}", license)
         }
     }
 }


### PR DESCRIPTION
This will add an option to display the full licenses of all dependencies. This is useful if you want to include a summary of the licenses in your project.

I also ran the latest rustfmt.