### PR TITLE
Update cargo to fix build, structured data output, extra dependency details, refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
 
 [dependencies]
-cargo = "0.30"
 failure = "0.1"
 getopts = "0.2.14"
 toml = "0.4"
@@ -17,6 +16,8 @@ csv = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
+cargo_metadata = "0.6.4"
+
 
 [[bin]]
 name = "cargo-license"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,14 @@ repository = "https://github.com/onur/cargo-license"
 
 [dependencies]
 cargo = "0.30"
-error-chain = "0.10"
+failure = "0.1"
 getopts = "0.2.14"
-toml = "0.2"
+toml = "0.4"
 ansi_term = "0.9"
+csv = "1"
+serde = "1"
+serde_derive = "1"
+serde_json = "1.0"
 
 [[bin]]
 name = "cargo-license"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
 
 [dependencies]
-cargo = "0.19"
+cargo = "0.30"
 error-chain = "0.10"
 getopts = "0.2.14"
 toml = "0.2"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 A cargo subcommand to see license of dependencies.
 
-
 ## Installation and Usage
 
 You can install cargo-license with: `cargo install cargo-license` and
@@ -16,13 +15,12 @@ Usage: cargo-license [options]
 
 Options:
     -a, --authors       Display crate authors
-    -d, --do-not-bundle 
+    -d, --do-not-bundle
                         Output one license per line.
+    -t, --tsv           detailed output as tab-separated-values
+    -j, --json          detailed output as json
     -h, --help          print this help menu
-
 ```
-
-
 
 ## Example
 

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -1,24 +1,37 @@
-
-extern crate cargo_license;
 extern crate ansi_term;
+extern crate cargo_license;
+extern crate csv;
+extern crate failure;
 extern crate getopts;
+extern crate serde_json;
 
-use std::env;
+use ansi_term::Colour::Green;
 use getopts::Options;
+use std::collections::btree_map::Entry::*;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::btree_map::Entry::*;
-use ansi_term::Colour::Green;
+use std::env;
+use std::io;
+use std::process::exit;
 
-fn group_by_license_type(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
-
-    let mut table: BTreeMap<String, Vec<cargo_license::Dependency>> = BTreeMap::new();
+fn group_by_license_type(
+    dependencies: Vec<cargo_license::DependencyDetails>,
+    display_authors: bool,
+) {
+    let mut table: BTreeMap<String, Vec<cargo_license::DependencyDetails>> = BTreeMap::new();
 
     for dependency in dependencies {
-        let license = dependency.get_license().unwrap_or("N/A".to_owned());
+        let license = dependency
+            .license
+            .clone()
+            .unwrap_or_else(|| "N/A".to_owned());
         match table.entry(license) {
-            Vacant(e) => {e.insert(vec![dependency]);},
-            Occupied(mut e) => {e.get_mut().push(dependency);},
+            Vacant(e) => {
+                e.insert(vec![dependency]);
+            }
+            Occupied(mut e) => {
+                e.get_mut().push(dependency);
+            }
         };
     }
 
@@ -26,89 +39,131 @@ fn group_by_license_type(dependencies: Vec<cargo_license::Dependency>, display_a
         let crate_names = crates.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
         if display_authors {
             let crate_authors = crates
-                    .iter()
-                    .flat_map(|c| c.get_authors().unwrap_or(vec![]))
-                    .collect::<BTreeSet<_>>();
-            println!("{} ({})\n{}\n{} {}",
-                     Green.bold().paint(license),
-                     crates.len(),
-                     crate_names.join(", "),
-                     Green.paint("by"),
-                     crate_authors.into_iter().collect::<Vec<_>>().join(", "));
+                .iter()
+                .map(|c| c.authors.clone().unwrap_or_else(|| "N/A".to_owned()))
+                .collect::<BTreeSet<_>>();
+            println!(
+                "{} ({})\n{}\n{} {}",
+                Green.bold().paint(license),
+                crates.len(),
+                crate_names.join(", "),
+                Green.paint("by"),
+                crate_authors.into_iter().collect::<Vec<_>>().join(", ")
+            );
         } else {
-            println!("{} ({}): {}",
-                     Green.bold().paint(license),
-                     crates.len(),
-                     crate_names.join(", "));
+            println!(
+                "{} ({}): {}",
+                Green.bold().paint(license),
+                crates.len(),
+                crate_names.join(", ")
+            );
         }
     }
 }
 
-fn one_license_per_line(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
-
+fn one_license_per_line(
+    dependencies: Vec<cargo_license::DependencyDetails>,
+    display_authors: bool,
+) {
     for dependency in dependencies {
         let name = dependency.name.clone();
         let version = dependency.version.clone();
-        let license = dependency.get_license().unwrap_or("N/A".to_owned());
+        let license = dependency.license.unwrap_or_else(|| "N/A".to_owned());
         let source = dependency.source.clone();
         if display_authors {
-            let authors = dependency.get_authors().unwrap_or(vec![]);
-            println!("{}: {}, \"{}\", {}, {} \"{}\"",
-                     Green.bold().paint(name),
-                     version,
-                     license,
-                     source,
-                     Green.paint("by"),
-                     authors.into_iter().collect::<Vec<_>>().join(", "));
+            let authors = dependency.authors.unwrap_or_else(|| "N/A".to_owned());
+            println!(
+                "{}: {}, \"{}\", {}, {} \"{}\"",
+                Green.bold().paint(name),
+                version,
+                license,
+                source,
+                Green.paint("by"),
+                authors
+            );
         } else {
-            println!("{}: {}, \"{}\", {}",
-                     Green.bold().paint(name),
-                     version,
-                     license,
-                     source);
+            println!(
+                "{}: {}, \"{}\", {}",
+                Green.bold().paint(name),
+                version,
+                license,
+                source
+            );
         }
-    };
-
+    }
 }
 
-fn print_usage(program: &str, opts: Options) {
+fn write_tsv(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
+    let mut wtr = csv::WriterBuilder::new()
+        .delimiter(b'\t')
+        .quote_style(csv::QuoteStyle::Necessary)
+        .from_writer(io::stdout());
+    for dependency in dependencies {
+        wtr.serialize(dependency)?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+fn write_json(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
+    println!("{}", serde_json::to_string_pretty(&dependencies)?);
+    Ok(())
+}
+
+fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options]", program);
     print!("{}", opts.usage(&brief));
 }
 
-fn main() {
+fn run() -> cargo_license::Result<()> {
     let args: Vec<String> = env::args().collect();
     let mut opts = Options::new();
     let program = args[0].clone();
     opts.optflag("a", "authors", "Display crate authors");
     opts.optflag("d", "do-not-bundle", "Output one license per line.");
+    opts.optflag("t", "tsv", "detailed output as tab-separated-values");
+    opts.optflag("j", "json", "detailed output as json");
     opts.optflag("h", "help", "print this help menu");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => { print_usage(&program, opts); 
-            panic!(f.to_string()) }
+        Err(f) => {
+            print_usage(&program, &opts);
+            panic!(f.to_string())
+        }
     };
     if matches.opt_present("h") {
-        print_usage(&program, opts);
-        return;
+        print_usage(&program, &opts);
+        return Ok(());
     }
 
     let display_authors = matches.opt_present("authors");
     let do_not_bundle = matches.opt_present("do-not-bundle");
+    let tsv = matches.opt_present("tsv");
+    let json = matches.opt_present("json");
 
-    let dependencies = match cargo_license::get_dependencies_from_cargo_lock() {
-        Ok(m) => m,
-        Err(err) => {
-            println!("Cargo.lock file not found. Try building the project first.\n{}", err);
-            std::process::exit(1);
-        }
-    };
+    let dependencies = cargo_license::get_dependencies_from_cargo_lock()?;
 
-    if do_not_bundle {
+    if tsv {
+        write_tsv(&dependencies)?
+    } else if json {
+        write_json(&dependencies)?
+    } else if do_not_bundle {
         one_license_per_line(dependencies, display_authors);
     } else {
         group_by_license_type(dependencies, display_authors);
     }
+    Ok(())
+}
 
+fn main() {
+    exit(match run() {
+        Ok(_) => 0,
+        Err(e) => {
+            for cause in e.iter_chain() {
+                eprintln!("{}", cause);
+            }
+            1
+        }
+    })
 }

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -69,25 +69,22 @@ fn one_license_per_line(
         let name = dependency.name.clone();
         let version = dependency.version.clone();
         let license = dependency.license.unwrap_or_else(|| "N/A".to_owned());
-        let source = dependency.source.clone();
         if display_authors {
             let authors = dependency.authors.unwrap_or_else(|| "N/A".to_owned());
             println!(
-                "{}: {}, \"{}\", {}, {} \"{}\"",
+                "{}: {}, \"{}\", {}, \"{}\"",
                 Green.bold().paint(name),
                 version,
                 license,
-                source,
                 Green.paint("by"),
                 authors
             );
         } else {
             println!(
-                "{}: {}, \"{}\", {}",
+                "{}: {}, \"{}\",",
                 Green.bold().paint(name),
                 version,
                 license,
-                source
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,14 @@ pub struct Dependency {
 
 impl Dependency {
     fn get_cargo_package(&self) -> CargoResult<cargo::core::Package> {
-        use cargo::core::{Source, SourceId, Registry};
+        use cargo::core::{Source, SourceId};
         use cargo::core::Dependency as CargoDependency;
-        use cargo::util::{Config, human};
+        use cargo::util::{Config, errors::internal};
         use cargo::sources::SourceConfigMap;
 
         // TODO: crates-license is only working for crates.io registry
         if !self.source.starts_with("registry") {
-            Err(human("registry sources are unimplemented"))?;
+            Err(internal("registry sources are unimplemented"))?;
         }
 
         let config = Config::default()?;
@@ -55,12 +55,12 @@ impl Dependency {
 
         let dep =
             CargoDependency::parse_no_deprecated(&self.name, Some(&self.version), &source_id)?;
-        let deps = source.query(&dep)?;
+        let deps = source.query_vec(&dep)?;
         deps.iter()
             .map(|p| p.package_id())
             .max()
             .map(|pkgid| source.download(pkgid))
-            .unwrap_or(Err(human("PKG download error")))
+            .unwrap_or(Err(internal("PKG download error")))
     }
 
     fn normalize(&self, license_string: &Option<String>) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,10 @@
 extern crate cargo_metadata;
-#[macro_use]
 extern crate failure;
 extern crate toml;
 #[macro_use]
 extern crate serde_derive;
 
 pub type Result<T> = std::result::Result<T, failure::Error>;
-
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
-struct MetadataError(String);
 
 fn normalize(license_string: &Option<String>) -> Option<String> {
     match license_string {
@@ -65,8 +60,8 @@ impl DependencyDetails {
 pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
     let mut path = std::env::current_dir()?;
     path.push("Cargo.toml");
-    let metadata = cargo_metadata::metadata_deps(Some(&path), true)
-        .map_err(|e| MetadataError(format!("{}", e)))?;
+    let metadata =
+        cargo_metadata::metadata_deps(Some(&path), true).map_err(failure::SyncFailure::new)?;
 
     let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
     for package in metadata.packages {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,15 @@
-extern crate cargo;
+extern crate cargo_metadata;
 #[macro_use]
 extern crate failure;
 extern crate toml;
 #[macro_use]
 extern crate serde_derive;
 
-use cargo::core;
-use cargo::sources::SourceConfigMap;
-use cargo::util::{errors::internal, Config};
-use std::fs;
-
 pub type Result<T> = std::result::Result<T, failure::Error>;
 
 #[derive(Debug, Fail)]
-pub enum LicenseError {
-    #[fail(display = "invalid configuration: {}", _0)]
-    InvalidConfiguration(String),
-}
+#[fail(display = "{}", _0)]
+struct MetadataError(String);
 
 fn normalize(license_string: &Option<String>) -> Option<String> {
     match license_string {
@@ -37,135 +30,47 @@ fn normalize(license_string: &Option<String>) -> Option<String> {
 pub struct DependencyDetails {
     pub name: String,
     pub version: String,
-    pub source: String,
     pub authors: Option<String>,
     pub repository: Option<String>,
     pub license: Option<String>,
     pub license_file: Option<String>,
-    pub repository_tree: Option<String>,
-    pub homepage: Option<String>,
     pub description: Option<String>,
 }
 
 impl DependencyDetails {
-    pub fn load(name: &str, version: &str, source: &str) -> Result<Vec<DependencyDetails>> {
-        // TODO: crates-license is only working for crates.io registry
-        if !source.starts_with("registry") {
-            Err(internal("registry sources are unimplemented"))?;
+    pub fn new(package: &cargo_metadata::Package) -> Self {
+        let authors = if package.authors.is_empty() {
+            None
+        } else {
+            Some(package.authors.to_owned().join("|"))
+        };
+        DependencyDetails {
+            name: package.name.to_owned(),
+            version: package.version.to_owned(),
+            authors,
+            repository: package.repository.to_owned(),
+            license: normalize(&package.license.to_owned()),
+            license_file: package
+                .license_file
+                .to_owned()
+                .and_then(|f| f.to_str().map(|x| x.to_owned())),
+            description: package
+                .description
+                .to_owned()
+                .map(|s| s.trim().replace("\n", " ")),
         }
-
-        let config = Config::default()?;
-        let source_id = core::SourceId::from_url(source)?;
-        let source_map = SourceConfigMap::new(&config)?;
-        let mut source_cfg = source_map.load(&source_id)?;
-        // update crates.io-index registry
-        source_cfg.update()?;
-
-        let primary_dependency: core::Dependency =
-            core::Dependency::parse_no_deprecated(name, Some(version), &source_id)?;
-        let summaries = source_cfg.query_vec(&primary_dependency)?;
-        let mut dependencies: Vec<DependencyDetails> = Vec::new();
-
-        for summery in summaries.iter() {
-            let pkg_id = summery.package_id();
-            let package = source_cfg.download(pkg_id)?;
-            let manifest_metadata = package.manifest().metadata();
-            let version = format!("{}", package.version());
-            let repo = &manifest_metadata.repository;
-
-            let repository_tree = match repo {
-                Some(r) => {
-                    if r.contains("github") || r.contains("gitlab") {
-                        Some(format!("{}/tree/v{}", r.to_owned(), version))
-                    } else {
-                        None
-                    }
-                }
-                None => None,
-            };
-
-            dependencies.push(DependencyDetails {
-                name: package.name().as_str().into(),
-                version,
-                source: source.to_owned(),
-                authors: Some(package.authors().to_owned().join("|")),
-                repository: repo.to_owned(),
-                license: normalize(&manifest_metadata.license.to_owned()),
-                license_file: manifest_metadata.license_file.to_owned(),
-                repository_tree,
-                homepage: manifest_metadata.homepage.to_owned(),
-                description: manifest_metadata
-                    .description
-                    .to_owned()
-                    .map(|s| s.trim().replace("\n", " ")),
-            });
-        }
-        Ok(dependencies)
     }
 }
 
 pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
-    let cargo_toml_value = fs::read_to_string("Cargo.toml")?.parse::<toml::Value>()?;
-    let cargo_toml = cargo_toml_value.as_table().ok_or_else(|| {
-        LicenseError::InvalidConfiguration("Unexpected format in Cargo.toml".into())
-    })?;
-
-    let cargo_lock_value = fs::read_to_string("Cargo.lock")?.parse::<toml::Value>()?;
-    let cargo_lock = cargo_lock_value.as_table().ok_or_else(|| {
-        LicenseError::InvalidConfiguration("Unexpected format in Cargo.lock".into())
-    })?;
-
-    let root_project = cargo_toml
-        .get("package")
-        .and_then(|x| x.get("name"))
-        .ok_or_else(|| {
-            LicenseError::InvalidConfiguration(
-                "Could not identify name of project in Cargo.toml".into(),
-            )
-        })?
-        .as_str()
-        .to_owned();
-
-    let packages = cargo_lock
-        .get("package")
-        .and_then(|p| p.as_array())
-        .ok_or_else(|| {
-            LicenseError::InvalidConfiguration("\"package\" not found in cargo.lock".into())
-        })?;
+    let mut path = std::env::current_dir()?;
+    path.push("Cargo.toml");
+    let metadata = cargo_metadata::metadata_deps(Some(&path), true)
+        .map_err(|e| MetadataError(format!("{}", e)))?;
 
     let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
-
-    for package in packages.iter() {
-        let p_table = package.as_table();
-        let name = p_table
-            .and_then(|n| n.get("name"))
-            .and_then(|n| n.as_str())
-            .to_owned()
-            .ok_or_else(|| {
-                LicenseError::InvalidConfiguration(
-                    "Could not identify name of dependency in Cargo.toml".into(),
-                )
-            })?;
-        let version = p_table
-            .and_then(|n| n.get("version"))
-            .and_then(|n| n.as_str())
-            .ok_or_else(|| {
-                LicenseError::InvalidConfiguration(
-                    "Could not identify version of dependency in Cargo.toml".into(),
-                )
-            })?;
-        // The source is empty for the source crate.
-        // It can be exclude it since it isn't a dependency.
-        let source = p_table
-            .and_then(|n| n.get("source"))
-            .and_then(|n| n.as_str())
-            .unwrap_or("");
-
-        if source.is_empty() && Some(name) == root_project {
-            continue;
-        } else {
-            detailed_dependencies.append(&mut DependencyDetails::load(name, version, source)?);
-        }
+    for package in metadata.packages {
+        detailed_dependencies.push(DependencyDetails::new(&package));
     }
     Ok(detailed_dependencies)
 }


### PR DESCRIPTION
I needed `cargo-license` to build on Fedora 29, and only recent versions of `cargo` have a compatible version if openssl. I used a branch made by @jswrenn as starting point, and then made the following changes:
- Use `serde` to optionally output `tsv` or `json`.
- Created a single `DependencyDetails` that maps every detail we might want. This can be output in full using `serde`, or it can be consumed by the existing writer functions in `cargo_license.rs`.
-  `DependencyDetails` will include a link to the source repository when available. It will also attempt to produce a link to the repository tree in github or gitlab for the exact version being referenced. 
- The source crate is excluded from the list since it's not a dependency. 
- Replaced `error_chain` with `failure`.
- Since `serde` is being pulled in already, I updated `toml` to the latest version that is based on `serde`. It also doesn't require unrolling Vec's of Errors.