### PR TITLE
Fix openssl build error, return structured data, extra dependency details

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,17 +2,22 @@
 name = "cargo-license"
 description = "Cargo subcommand to see license of dependencies"
 authors = ["Onur Aslan <onur@onur.im>"]
-version = "0.1.5"
+version = "0.2.0"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
 
 [dependencies]
-cargo = "0.30"
-error-chain = "0.10"
+failure = "0.1"
 getopts = "0.2.14"
-toml = "0.2"
+toml = "0.4"
 ansi_term = "0.9"
+csv = "1"
+serde = "1"
+serde_derive = "1"
+serde_json = "1.0"
+cargo_metadata = "0.6.4"
+
 
 [[bin]]
 name = "cargo-license"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
 
 [dependencies]
-cargo = "0.19"
+cargo = "0.30"
 error-chain = "0.10"
 getopts = "0.2.14"
 toml = "0.2"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 A cargo subcommand to see license of dependencies.
 
-
 ## Installation and Usage
 
 You can install cargo-license with: `cargo install cargo-license` and
@@ -16,13 +15,12 @@ Usage: cargo-license [options]
 
 Options:
     -a, --authors       Display crate authors
-    -d, --do-not-bundle 
+    -d, --do-not-bundle
                         Output one license per line.
+    -t, --tsv           detailed output as tab-separated-values
+    -j, --json          detailed output as json
     -h, --help          print this help menu
-
 ```
-
-
 
 ## Example
 

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -1,24 +1,37 @@
-
-extern crate cargo_license;
 extern crate ansi_term;
+extern crate cargo_license;
+extern crate csv;
+extern crate failure;
 extern crate getopts;
+extern crate serde_json;
 
-use std::env;
+use ansi_term::Colour::Green;
 use getopts::Options;
+use std::collections::btree_map::Entry::*;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::btree_map::Entry::*;
-use ansi_term::Colour::Green;
+use std::env;
+use std::io;
+use std::process::exit;
 
-fn group_by_license_type(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
-
-    let mut table: BTreeMap<String, Vec<cargo_license::Dependency>> = BTreeMap::new();
+fn group_by_license_type(
+    dependencies: Vec<cargo_license::DependencyDetails>,
+    display_authors: bool,
+) {
+    let mut table: BTreeMap<String, Vec<cargo_license::DependencyDetails>> = BTreeMap::new();
 
     for dependency in dependencies {
-        let license = dependency.get_license().unwrap_or("N/A".to_owned());
+        let license = dependency
+            .license
+            .clone()
+            .unwrap_or_else(|| "N/A".to_owned());
         match table.entry(license) {
-            Vacant(e) => {e.insert(vec![dependency]);},
-            Occupied(mut e) => {e.get_mut().push(dependency);},
+            Vacant(e) => {
+                e.insert(vec![dependency]);
+            }
+            Occupied(mut e) => {
+                e.get_mut().push(dependency);
+            }
         };
     }
 
@@ -26,89 +39,128 @@ fn group_by_license_type(dependencies: Vec<cargo_license::Dependency>, display_a
         let crate_names = crates.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
         if display_authors {
             let crate_authors = crates
-                    .iter()
-                    .flat_map(|c| c.get_authors().unwrap_or(vec![]))
-                    .collect::<BTreeSet<_>>();
-            println!("{} ({})\n{}\n{} {}",
-                     Green.bold().paint(license),
-                     crates.len(),
-                     crate_names.join(", "),
-                     Green.paint("by"),
-                     crate_authors.into_iter().collect::<Vec<_>>().join(", "));
+                .iter()
+                .map(|c| c.authors.clone().unwrap_or_else(|| "N/A".to_owned()))
+                .collect::<BTreeSet<_>>();
+            println!(
+                "{} ({})\n{}\n{} {}",
+                Green.bold().paint(license),
+                crates.len(),
+                crate_names.join(", "),
+                Green.paint("by"),
+                crate_authors.into_iter().collect::<Vec<_>>().join(", ")
+            );
         } else {
-            println!("{} ({}): {}",
-                     Green.bold().paint(license),
-                     crates.len(),
-                     crate_names.join(", "));
+            println!(
+                "{} ({}): {}",
+                Green.bold().paint(license),
+                crates.len(),
+                crate_names.join(", ")
+            );
         }
     }
 }
 
-fn one_license_per_line(dependencies: Vec<cargo_license::Dependency>, display_authors: bool) {
-
+fn one_license_per_line(
+    dependencies: Vec<cargo_license::DependencyDetails>,
+    display_authors: bool,
+) {
     for dependency in dependencies {
         let name = dependency.name.clone();
         let version = dependency.version.clone();
-        let license = dependency.get_license().unwrap_or("N/A".to_owned());
-        let source = dependency.source.clone();
+        let license = dependency.license.unwrap_or_else(|| "N/A".to_owned());
         if display_authors {
-            let authors = dependency.get_authors().unwrap_or(vec![]);
-            println!("{}: {}, \"{}\", {}, {} \"{}\"",
-                     Green.bold().paint(name),
-                     version,
-                     license,
-                     source,
-                     Green.paint("by"),
-                     authors.into_iter().collect::<Vec<_>>().join(", "));
+            let authors = dependency.authors.unwrap_or_else(|| "N/A".to_owned());
+            println!(
+                "{}: {}, \"{}\", {}, \"{}\"",
+                Green.bold().paint(name),
+                version,
+                license,
+                Green.paint("by"),
+                authors
+            );
         } else {
-            println!("{}: {}, \"{}\", {}",
-                     Green.bold().paint(name),
-                     version,
-                     license,
-                     source);
+            println!(
+                "{}: {}, \"{}\",",
+                Green.bold().paint(name),
+                version,
+                license,
+            );
         }
-    };
-
+    }
 }
 
-fn print_usage(program: &str, opts: Options) {
+fn write_tsv(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
+    let mut wtr = csv::WriterBuilder::new()
+        .delimiter(b'\t')
+        .quote_style(csv::QuoteStyle::Necessary)
+        .from_writer(io::stdout());
+    for dependency in dependencies {
+        wtr.serialize(dependency)?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+fn write_json(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
+    println!("{}", serde_json::to_string_pretty(&dependencies)?);
+    Ok(())
+}
+
+fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options]", program);
     print!("{}", opts.usage(&brief));
 }
 
-fn main() {
+fn run() -> cargo_license::Result<()> {
     let args: Vec<String> = env::args().collect();
     let mut opts = Options::new();
     let program = args[0].clone();
     opts.optflag("a", "authors", "Display crate authors");
     opts.optflag("d", "do-not-bundle", "Output one license per line.");
+    opts.optflag("t", "tsv", "detailed output as tab-separated-values");
+    opts.optflag("j", "json", "detailed output as json");
     opts.optflag("h", "help", "print this help menu");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => { print_usage(&program, opts); 
-            panic!(f.to_string()) }
+        Err(f) => {
+            print_usage(&program, &opts);
+            panic!(f.to_string())
+        }
     };
     if matches.opt_present("h") {
-        print_usage(&program, opts);
-        return;
+        print_usage(&program, &opts);
+        return Ok(());
     }
 
     let display_authors = matches.opt_present("authors");
     let do_not_bundle = matches.opt_present("do-not-bundle");
+    let tsv = matches.opt_present("tsv");
+    let json = matches.opt_present("json");
 
-    let dependencies = match cargo_license::get_dependencies_from_cargo_lock() {
-        Ok(m) => m,
-        Err(err) => {
-            println!("Cargo.lock file not found. Try building the project first.\n{}", err);
-            std::process::exit(1);
-        }
-    };
+    let dependencies = cargo_license::get_dependencies_from_cargo_lock()?;
 
-    if do_not_bundle {
+    if tsv {
+        write_tsv(&dependencies)?
+    } else if json {
+        write_json(&dependencies)?
+    } else if do_not_bundle {
         one_license_per_line(dependencies, display_authors);
     } else {
         group_by_license_type(dependencies, display_authors);
     }
+    Ok(())
+}
 
+fn main() {
+    exit(match run() {
+        Ok(_) => 0,
+        Err(e) => {
+            for cause in e.iter_chain() {
+                eprintln!("{}", cause);
+            }
+            1
+        }
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,14 @@ pub struct Dependency {
 
 impl Dependency {
     fn get_cargo_package(&self) -> CargoResult<cargo::core::Package> {
-        use cargo::core::{Source, SourceId, Registry};
+        use cargo::core::{Source, SourceId};
         use cargo::core::Dependency as CargoDependency;
-        use cargo::util::{Config, human};
+        use cargo::util::{Config, errors::internal};
         use cargo::sources::SourceConfigMap;
 
         // TODO: crates-license is only working for crates.io registry
         if !self.source.starts_with("registry") {
-            Err(human("registry sources are unimplemented"))?;
+            Err(internal("registry sources are unimplemented"))?;
         }
 
         let config = Config::default()?;
@@ -55,12 +55,12 @@ impl Dependency {
 
         let dep =
             CargoDependency::parse_no_deprecated(&self.name, Some(&self.version), &source_id)?;
-        let deps = source.query(&dep)?;
+        let deps = source.query_vec(&dep)?;
         deps.iter()
             .map(|p| p.package_id())
             .max()
             .map(|pkgid| source.download(pkgid))
-            .unwrap_or(Err(human("PKG download error")))
+            .unwrap_or(Err(internal("PKG download error")))
     }
 
     fn normalize(&self, license_string: &Option<String>) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,157 +1,82 @@
-
-
-extern crate cargo;
+extern crate cargo_metadata;
+extern crate failure;
 extern crate toml;
 #[macro_use]
-extern crate error_chain;
+extern crate serde_derive;
 
-use std::io;
-use cargo::util::CargoResult;
+pub type Result<T> = std::result::Result<T, failure::Error>;
 
-// I thought this crate is a good example to learn error_chain
-// but looks like no need of it in this crate
-error_chain! {
-    types {
-        Error, ErrorKind, ChainErr, Result;
-    }
-
-    links {}
-
-    foreign_links {
-        Io(io::Error);
-    }
-
-    errors {}
+fn normalize(license_string: &str) -> String {
+    let mut list: Vec<&str> = license_string
+        .split('/')
+        .map(|e| e.trim())
+        .collect();
+    list.sort();
+    list.dedup();
+    list.join("|")
 }
 
-#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct Dependency {
+#[derive(Debug, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct DependencyDetails {
     pub name: String,
     pub version: String,
-    pub source: String,
+    pub authors: Option<String>,
+    pub repository: Option<String>,
+    pub license: Option<String>,
+    pub license_file: Option<String>,
+    pub description: Option<String>,
 }
 
-
-impl Dependency {
-    fn get_cargo_package(&self) -> CargoResult<cargo::core::Package> {
-        use cargo::core::{Source, SourceId};
-        use cargo::core::Dependency as CargoDependency;
-        use cargo::util::{Config, errors::internal};
-        use cargo::sources::SourceConfigMap;
-
-        // TODO: crates-license is only working for crates.io registry
-        if !self.source.starts_with("registry") {
-            Err(internal("registry sources are unimplemented"))?;
-        }
-
-        let config = Config::default()?;
-        let source_id = SourceId::from_url(&self.source)?;
-
-        let source_map = SourceConfigMap::new(&config)?;
-        let mut source = source_map.load(&source_id)?;
-
-        // update crates.io-index registry
-        source.update()?;
-
-        let dep =
-            CargoDependency::parse_no_deprecated(&self.name, Some(&self.version), &source_id)?;
-        let deps = source.query_vec(&dep)?;
-        deps.iter()
-            .map(|p| p.package_id())
-            .max()
-            .map(|pkgid| source.download(pkgid))
-            .unwrap_or(Err(internal("PKG download error")))
-    }
-
-    fn normalize(&self, license_string: &Option<String>) -> Option<String> {
-        match license_string {
-            &None => None,
-            &Some(ref license) => {
-                let mut list: Vec<&str> = license.split('/').collect();
-                for elem in list.iter_mut() {
-                    *elem = elem.trim();
-                }
-                list.sort();
-                list.dedup();
-                Some(list.join("/"))
-            }
-        }
-    }
-
-    pub fn get_authors(&self) -> CargoResult<Vec<String>> {
-        let pkg = self.get_cargo_package()?;
-        Ok(pkg.manifest().metadata().authors.clone())
-    }
-
-    pub fn get_license(&self) -> Option<String> {
-        match self.get_cargo_package() {
-            Ok(pkg) => {
-                self.normalize(&pkg.manifest().metadata().license)
-            }
-            Err(_) => None,
+impl DependencyDetails {
+    pub fn new(package: &cargo_metadata::Package) -> Self {
+        let authors = if package.authors.is_empty() {
+            None
+        } else {
+            Some(package.authors.to_owned().join("|"))
+        };
+        DependencyDetails {
+            name: package.name.to_owned(),
+            version: package.version.to_owned(),
+            authors,
+            repository: package.repository.to_owned(),
+            license: package.license.as_ref().map(|s| normalize(&s)),
+            license_file: package
+                .license_file
+                .to_owned()
+                .and_then(|f| f.to_str().map(|x| x.to_owned())),
+            description: package
+                .description
+                .to_owned()
+                .map(|s| s.trim().replace("\n", " ")),
         }
     }
 }
 
+pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
+    let mut path = std::env::current_dir()?;
+    path.push("Cargo.toml");
+    let metadata =
+        cargo_metadata::metadata_deps(Some(&path), true).map_err(failure::SyncFailure::new)?;
 
-
-pub fn get_dependencies_from_cargo_lock() -> Result<Vec<Dependency>> {
-    let toml = {
-        use std::fs::File;
-        use std::io::Read;
-
-        let lock_file = File::open("Cargo.lock")?;
-        let mut reader = io::BufReader::new(lock_file);
-        let mut content = String::new();
-        reader.read_to_string(&mut content)?;
-        content
-    };
-
-    // This code once was beautiful, but it became ugly after rustfmt
-    let dependencies: Vec<Dependency> = toml::Parser::new(&toml)
-                                                 .parse()
-                                                 .as_ref()
-                                                 .and_then(|p| p.get("package"))
-                                                 .and_then(|p| p.as_slice())
-                                                 .ok_or("Package not found")
-                                                 .map(|p| {
-        p.iter()
-            .map(|p| {
-                Dependency {
-                    name: p.as_table()
-                        .and_then(|n| n.get("name"))
-                        .and_then(|n| n.as_str())
-                        .unwrap()
-                        .to_owned(),
-                    version: p.as_table()
-                        .and_then(|n| n.get("version"))
-                        .and_then(|n| n.as_str())
-                        .unwrap()
-                        .to_owned(),
-                    source: p.as_table()
-                        .and_then(|n| n.get("source"))
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_owned(),
-                }
-            })
-            .collect()
-    })?;
-
-    Ok(dependencies)
+    let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
+    for package in metadata.packages {
+        detailed_dependencies.push(DependencyDetails::new(&package));
+    }
+    Ok(detailed_dependencies)
 }
-
-
 
 #[cfg(test)]
 mod test {
-    use super::get_dependencies_from_cargo_lock;
+    use super::*;
 
     #[test]
-    fn test() {
-
-        for dependency in get_dependencies_from_cargo_lock().unwrap() {
-            assert!(!dependency.get_license().unwrap().is_empty());
+    fn test_detailed() {
+        let detailed_dependencies = get_dependencies_from_cargo_lock().unwrap();
+        assert!(!detailed_dependencies.is_empty());
+        for detailed_dependency in detailed_dependencies.iter() {
+            assert!(
+                detailed_dependency.license.is_some() || detailed_dependency.license_file.is_some()
+            );
         }
     }
 }


### PR DESCRIPTION
I needed `cargo-license` to build on Fedora 29, and only recent versions of `cargo` have a compatible version of openssl. I used a branch made by @jswrenn as starting point, and then made the following changes:

- Use `cargo_metadata` instead of directly using `cargo` to collect package data. `cargo_metadata` uses a recent version of cargo that does not have the build issue with recent versions of openssl. 
- Use `serde` to optionally output `tsv` or `json`.
- Created a single `DependencyDetails` that maps every detail we might want. This can be output in full using `serde`, or it can be consumed by the existing writer functions in `cargo_license.rs`.
-  `DependencyDetails` will include a link to the source repository when available.
- Replaced `error_chain` with `failure`.
- Since `serde` is being pulled in already, I updated `toml` to the latest version that is based on `serde`. It also doesn't require unrolling Vec's of Errors.

I also bumped the version to `0.2.0`.

Originally opened here, https://github.com/onur/cargo-license/pull/13 but I needed to change the github org.


