### PR TITLE
Update to `cargo_metadata` 0.8.0 from 0.6.3, add `semver` 0.9.0 dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ csv = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
-cargo_metadata = "0.6.4"
-
+cargo_metadata = "0.8.0"
+semver = "0.9.0"
 
 [[bin]]
 name = "cargo-license"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ fn normalize(license_string: &str) -> String {
 #[derive(Debug, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct DependencyDetails {
     pub name: String,
-    pub version: String,
+    pub version: semver::Version,
     pub authors: Option<String>,
     pub repository: Option<String>,
     pub license: Option<String>,
@@ -56,7 +56,7 @@ pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
     let mut path = std::env::current_dir()?;
     path.push("Cargo.toml");
     let metadata =
-        cargo_metadata::metadata_deps(Some(&path), true).map_err(failure::SyncFailure::new)?;
+        cargo_metadata::MetadataCommand::new().manifest_path(&path).exec()?;
 
     let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
     for package in metadata.packages {


### PR DESCRIPTION
This bumps the MSRV to 1.32 because that's what upstream `cargo-metadata` depends upon. None seems to have been specified for this project until now, so this may be a valid reason to discuss before merging or reject outright. Your call!