### PR TITLE
Merge licenses with OR combinator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,12 @@ pub type Result<T> = std::result::Result<T, failure::Error>;
 fn normalize(license_string: &str) -> String {
     let mut list: Vec<&str> = license_string
         .split('/')
-        .map(|e| e.trim())
+        .flat_map(|e| e.split(" OR "))
+        .map(str::trim)
         .collect();
     list.sort();
     list.dedup();
-    list.join("/")
+    list.join(" OR ")
 }
 
 #[derive(Debug, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]


### PR DESCRIPTION
Currently multiple licenses are being split by `/` which is now a deprecated separator (https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata).

The new separator is `OR` which is added with this PR. After de-duplication and sorting the `OR` separator will be used to combine the items into a single string again as well.

This should remove many duplicates in bigger projects with many dependencies. For example:
`MIT OR Apache-2.0`, `MIT / Apache-2.0` and `Apache-2.0 OR MIT` would all become a single `Apache-2.0 OR MIT`.