### PR TITLE
Update cargo_metadata, allow feature selection, misc improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ csv = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
-cargo_metadata = "0.6.4"
-
+cargo_metadata = "0.8.0"
+semver = "0.9.0"
 
 [[bin]]
 name = "cargo-license"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 name = "cargo-license"
 description = "Cargo subcommand to see license of dependencies"
 authors = ["Onur Aslan <onur@onur.im>"]
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
+edition = "2018"
 
 [dependencies]
 failure = "0.1"
@@ -16,8 +17,9 @@ csv = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1.0"
-cargo_metadata = "0.8.0"
+cargo_metadata = "0.9.1"
 semver = "0.9.0"
+structopt = "0.3"
 
 [[bin]]
 name = "cargo-license"

--- a/README.md
+++ b/README.md
@@ -11,15 +11,26 @@ You can install cargo-license with: `cargo install cargo-license` and
 run it in your project directory with: `cargo license` or `cargo-license`.
 
 ```
-Usage: cargo-license [options]
+cargo_license 0.3.0
+Cargo subcommand to see licenses of dependencies.
 
-Options:
-    -a, --authors       Display crate authors
-    -d, --do-not-bundle
-                        Output one license per line.
-    -t, --tsv           detailed output as tab-separated-values
-    -j, --json          detailed output as json
-    -h, --help          print this help menu
+USAGE:
+    cargo-license [FLAGS] [OPTIONS]
+
+FLAGS:
+        --all-features     Activate all available features.
+    -a, --authors          Display crate authors
+    -d, --do-not-bundle    Output one license per line.
+    -h, --help             Prints help information
+    -j, --json             Detailed output as JSON.
+        --no-deps          Output information only about the root package and don't fetch dependencies.
+    -t, --tsv              Detailed output as tab-separated-values.
+    -V, --version          Prints version information
+
+OPTIONS:
+        --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process.
+        --features <FEATURE>...        Space-separated list of features to activate.
+        --manifest-path <PATH>         Path to Cargo.toml.
 ```
 
 ## Example

--- a/src/cargo-license.rs
+++ b/src/cargo-license.rs
@@ -12,7 +12,6 @@ use std::collections::BTreeSet;
 use std::io;
 use std::path::PathBuf;
 use std::process::exit;
-use structopt;
 use structopt::StructOpt;
 
 fn group_by_license_type(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ fn normalize(license_string: &str) -> String {
 #[derive(Debug, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct DependencyDetails {
     pub name: String,
-    pub version: String,
+    pub version: semver::Version,
     pub authors: Option<String>,
     pub repository: Option<String>,
     pub license: Option<String>,
@@ -56,7 +56,7 @@ pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
     let mut path = std::env::current_dir()?;
     path.push("Cargo.toml");
     let metadata =
-        cargo_metadata::metadata_deps(Some(&path), true).map_err(failure::SyncFailure::new)?;
+        cargo_metadata::MetadataCommand::new().manifest_path(&path).exec()?;
 
     let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
     for package in metadata.packages {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,10 @@ impl DependencyDetails {
     }
 }
 
-pub fn get_dependencies_from_cargo_lock() -> Result<Vec<DependencyDetails>> {
-    let mut path = std::env::current_dir()?;
-    path.push("Cargo.toml");
-    let metadata =
-        cargo_metadata::MetadataCommand::new().manifest_path(&path).exec()?;
+pub fn get_dependencies_from_cargo_lock(
+    mut metadata_command: cargo_metadata::MetadataCommand,
+) -> Result<Vec<DependencyDetails>> {
+    let metadata = metadata_command.exec()?;
 
     let mut detailed_dependencies: Vec<DependencyDetails> = Vec::new();
     for package in metadata.packages {
@@ -71,7 +70,8 @@ mod test {
 
     #[test]
     fn test_detailed() {
-        let detailed_dependencies = get_dependencies_from_cargo_lock().unwrap();
+        let cmd = cargo_metadata::MetadataCommand::new();
+        let detailed_dependencies = get_dependencies_from_cargo_lock(cmd).unwrap();
         assert!(!detailed_dependencies.is_empty());
         for detailed_dependency in detailed_dependencies.iter() {
             assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,12 @@ pub type Result<T> = std::result::Result<T, failure::Error>;
 fn normalize(license_string: &str) -> String {
     let mut list: Vec<&str> = license_string
         .split('/')
-        .map(|e| e.trim())
+        .flat_map(|e| e.split(" OR "))
+        .map(str::trim)
         .collect();
     list.sort();
     list.dedup();
-    list.join("/")
+    list.join(" OR ")
 }
 
 #[derive(Debug, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]


### PR DESCRIPTION
This PR extends some of `cargo_metadata`'s arguments into `cargo-license` like `--features`, `--all-features`, `--no-deps`, `--manifest-path` and `--current-dir`. 

This PR also includes improvements from other PRs.
https://github.com/onur/cargo-license/pull/19 @dnaka91 I included a minor bump for this change.
https://github.com/onur/cargo-license/pull/17 & https://github.com/onur/cargo-license/pull/16 @ErichDonGubler

@onur 
