### PR TITLE
Make the order of the output deterministic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn get_dependencies_from_cargo_lock(
     for package in metadata.packages {
         detailed_dependencies.push(DependencyDetails::new(&package));
     }
+    detailed_dependencies.sort_by(|dep1, dep2| dep1.cmp(dep2));
     Ok(detailed_dependencies)
 }
 


### PR DESCRIPTION
Instead of printing the dependencies in the order we get them from the
cargo metadata, we sort them by their package names.

This is helpful in situations where you use `cargo-license` to generate
a `NOTICES` file that gets checked into the repository and want to
enfore in CI that the file is up to date.

Since the previous output was in a seemingly random order and the
performance penalty for sorting is rather small, I decided to not hide
this behavior behind a flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onur/cargo-license/26)
<!-- Reviewable:end -->
