### PR TITLE
Improve usage as cargo subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn write_json(dependencies: &[cargo_license::DependencyDetails]) -> cargo_licens
 
 #[derive(Debug, StructOpt)]
 #[structopt(
-    name = "cargo_license",
+    bin_name = "cargo license",
     about = "Cargo subcommand to see licenses of dependencies."
 )]
 struct Opt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,18 @@ struct Opt {
 }
 
 fn run() -> cargo_license::Result<()> {
-    let opt = Opt::from_args();
+    use std::env;
+
+    // Drop extra `license` argument when called by `cargo`.
+    let args = env::args().enumerate().filter_map(|(i, x)| {
+        if (i, x.as_str()) != (1, "license") {
+            Some(x)
+        } else {
+            None
+        }
+    });
+
+    let opt = Opt::from_iter(args);
     let mut cmd = cargo_metadata::MetadataCommand::new();
 
     if let Some(path) = &opt.manifest_path {


### PR DESCRIPTION
Drops the extra `license` argument received when being called with `cargo license`.  Additionally, change the binary name displayed in the help message, for uniformity with other Cargo subcommands.  Based on how `cargo-fmt` handles this.

```
$ cargo license --help
cargo-license 0.3.0
Cargo subcommand to see licenses of dependencies.

USAGE:
    cargo license [FLAGS] [OPTIONS]

FLAGS:
        --all-features     Activate all available features
    -a, --authors          Display crate authors
    -d, --do-not-bundle    Output one license per line
    -h, --help             Prints help information
    -j, --json             Detailed output as JSON
        --no-deps          Output information only about the root package and don't fetch dependencies
    -t, --tsv              Detailed output as tab-separated-values
    -V, --version          Prints version information

OPTIONS:
        --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process
        --features <FEATURE>...        Space-separated list of features to activate
        --manifest-path <PATH>         Path to Cargo.toml
```

```
$ cargo-license --help
cargo-license 0.3.0
Cargo subcommand to see licenses of dependencies.

USAGE:
    cargo license [FLAGS] [OPTIONS]

FLAGS:
        --all-features     Activate all available features
    -a, --authors          Display crate authors
    -d, --do-not-bundle    Output one license per line
    -h, --help             Prints help information
    -j, --json             Detailed output as JSON
        --no-deps          Output information only about the root package and don't fetch dependencies
    -t, --tsv              Detailed output as tab-separated-values
    -V, --version          Prints version information

OPTIONS:
        --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process
        --features <FEATURE>...        Space-separated list of features to activate
        --manifest-path <PATH>         Path to Cargo.toml
```

Closes: #23
Closes: #25
Supersedes: #27
Supersedes: #29