### PR TITLE
Add `--avoid-dev-deps` and `--avoid-build-deps`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,14 @@ struct Opt {
     /// Detailed output as JSON.
     json: bool,
 
+    #[structopt(long)]
+    /// Exclude development dependencies
+    avoid_dev_deps: bool,
+
+    #[structopt(long)]
+    /// Exclude build dependencies
+    avoid_build_deps: bool,
+
     #[structopt(long = "features", name = "FEATURE")]
     /// Space-separated list of features to activate.
     features: Option<Vec<String>>,
@@ -195,7 +203,11 @@ fn run() -> cargo_license::Result<()> {
         cmd.features(cargo_metadata::CargoOpt::SomeFeatures(features));
     }
 
-    let dependencies = cargo_license::get_dependencies_from_cargo_lock(cmd)?;
+    let dependencies = cargo_license::get_dependencies_from_cargo_lock(
+        cmd,
+        opt.avoid_dev_deps,
+        opt.avoid_build_deps,
+    )?;
 
     let enable_color = if let Some(color) = opt.color {
         match color.as_ref() {


### PR DESCRIPTION
Closes #18.

```diff
 cargo-license 0.4.0
 Cargo subcommand to see licenses of dependencies.

 USAGE:
     cargo license [FLAGS] [OPTIONS]

 FLAGS:
         --all-features        Activate all available features
     -a, --authors             Display crate authors
+        --avoid-build-deps    Exclude build dependencies
+        --avoid-dev-deps      Exclude development dependencies
     -d, --do-not-bundle       Output one license per line
     -h, --help                Prints help information
     -j, --json                Detailed output as JSON
         --no-deps             Output information only about the root package and don't fetch dependencies
     -t, --tsv                 Detailed output as tab-separated-values
     -V, --version             Prints version information

 OPTIONS:
         --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process
         --features <FEATURE>...        Space-separated list of features to activate
         --manifest-path <PATH>         Path to Cargo.toml
         --color <WHEN>                 Coloring [possible values: auto, always, never]
```
