### PR TITLE
Fix CLI options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,11 @@ fn write_json(dependencies: &[cargo_license::DependencyDetails]) -> cargo_licens
     about = "Cargo subcommand to see licenses of dependencies."
 )]
 struct Opt {
-    #[structopt(name = "PATH", long)]
+    #[structopt(value_name = "PATH", long)]
     /// Path to Cargo.toml.
     manifest_path: Option<PathBuf>,
 
-    #[structopt(name = "CURRENT_DIR", long)]
+    #[structopt(value_name = "CURRENT_DIR", long)]
     /// Current directory of the cargo metadata process.
     current_dir: Option<PathBuf>,
 
@@ -141,7 +141,7 @@ struct Opt {
     /// Detailed output as JSON.
     json: bool,
 
-    #[structopt(long = "features", name = "FEATURE")]
+    #[structopt(long = "features", value_name = "FEATURE")]
     /// Space-separated list of features to activate.
     features: Option<Vec<String>>,
 


### PR DESCRIPTION
#37 broke the 2 options...

```diff
 cargo-license 0.4.0
 Cargo subcommand to see licenses of dependencies.

 USAGE:
     cargo license [FLAGS] [OPTIONS]

 FLAGS:
         --all-features     Activate all available features
     -a, --authors          Display crate authors
     -d, --do-not-bundle    Output one license per line
     -h, --help             Prints help information
     -j, --json             Detailed output as JSON
         --no-deps          Output information only about the root package and don't fetch dependencies
     -t, --tsv              Detailed output as tab-separated-values
     -V, --version          Prints version information

 OPTIONS:
-        --CURRENT_DIR <CURRENT_DIR>    Current directory of the cargo metadata process
-        --features <FEATURE>...        Space-separated list of features to activate
-        --PATH <PATH>                  Path to Cargo.toml
         --color <WHEN>                 Coloring [possible values: auto, always, never]
+        --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process
+        --features <FEATURE>...        Space-separated list of features to activate
+        --manifest-path <PATH>         Path to Cargo.toml
```
