### PR TITLE
Enable filtering by platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,23 @@ USAGE:
     cargo license [FLAGS] [OPTIONS]
 
 FLAGS:
-        --all-features     Activate all available features
-    -a, --authors          Display crate authors
-    -d, --do-not-bundle    Output one license per line
-    -h, --help             Prints help information
-    -j, --json             Detailed output as JSON
-        --no-deps          Output information only about the root package and don't fetch dependencies
-    -t, --tsv              Detailed output as tab-separated-values
-    -V, --version          Prints version information
+        --all-features        Activate all available features
+    -a, --authors             Display crate authors
+        --avoid-build-deps    Exclude build dependencies
+        --avoid-dev-deps      Exclude development dependencies
+    -d, --do-not-bundle       Output one license per line
+    -h, --help                Prints help information
+    -j, --json                Detailed output as JSON
+        --no-deps             Output information only about the root package and don't fetch dependencies
+    -t, --tsv                 Detailed output as tab-separated-values
+    -V, --version             Prints version information
 
 OPTIONS:
+        --color <WHEN>                 Coloring [possible values: auto, always, never]
         --current-dir <CURRENT_DIR>    Current directory of the cargo metadata process
         --features <FEATURE>...        Space-separated list of features to activate
+        --filter-platform <TRIPLE>     Only include resolve dependencies matching the given target-triple
         --manifest-path <PATH>         Path to Cargo.toml
-        --color <WHEN>                 Coloring [possible values: auto, always, never]
 ```
 
 ## Example

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,10 @@ struct Opt {
     /// Output information only about the root package and don't fetch dependencies.
     no_deps: bool,
 
+    #[structopt(long = "filter-platform", value_name = "TRIPLE")]
+    /// Only include resolve dependencies matching the given target-triple.
+    filter_platform: Option<String>,
+
     #[structopt(
         long = "color",
         name = "WHEN",
@@ -201,6 +205,9 @@ fn run() -> cargo_license::Result<()> {
     }
     if let Some(features) = opt.features {
         cmd.features(cargo_metadata::CargoOpt::SomeFeatures(features));
+    }
+    if let Some(triple) = opt.filter_platform {
+        cmd.other_options(&["--filter-platform".into(), triple]);
     }
 
     let dependencies = cargo_license::get_dependencies_from_cargo_lock(


### PR DESCRIPTION
Closes #42

Before
```
./../forks/cargo-license/target/debug/cargo-license --avoid-build-deps --avoid-dev-deps
Apache-2.0 (1): ...
Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT (1): ...
Apache-2.0 OR MIT (38): ...
Apache-2.0 OR MIT OR Zlib (2): ...
MIT (8): ...
```

After
```
../../forks/cargo-license/target/debug/cargo-license --filter-platform x86_64-apple-darwin --avoid-build-deps --avoid-dev-deps
Apache-2.0 (1): ...
Apache-2.0 OR MIT (34): ...
Apache-2.0 OR MIT OR Zlib (2): ...
MIT (8): ...
```