### PR TITLE
add `--root-only`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.4.2"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 getopts = "0.2.21"
@@ -18,6 +18,6 @@ serde_derive = "1"
 serde_json = "1"
 cargo_metadata = "0.14.0"
 semver = "1.0"
-clap = { version =  "3.0.7", features = ["derive"] }
+clap = { version =  "3.1.17", features = ["derive"] }
 atty = "0.2"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ FLAGS:
     -a, --authors             Display crate authors
         --avoid-build-deps    Exclude build dependencies
         --avoid-dev-deps      Exclude development dependencies
+        --direct-deps-only    Output information only about the root package and it's direct dependencies
     -d, --do-not-bundle       Output one license per line
     -h, --help                Prints help information
     -j, --json                Detailed output as JSON
         --no-default-features Deactivate default features
-        --no-deps             Output information only about the root package and don't fetch dependencies
     -t, --tsv                 Detailed output as tab-separated-values
     -V, --version             Prints version information
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ FLAGS:
     -d, --do-not-bundle       Output one license per line
     -h, --help                Prints help information
     -j, --json                Detailed output as JSON
+        --no-default-features Deactivate default features
         --no-deps             Output information only about the root package and don't fetch dependencies
     -t, --tsv                 Detailed output as tab-separated-values
     -V, --version             Prints version information

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ FLAGS:
     -h, --help                Prints help information
     -j, --json                Detailed output as JSON
         --no-default-features Deactivate default features
+        --root-only           Output information only about the root package
     -t, --tsv                 Detailed output as tab-separated-values
     -V, --version             Prints version information
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,13 @@ fn get_node_name_filter(metadata: &Metadata, opt: &GetDependenciesOpt) -> Result
         .root_package()
         .ok_or_else(|| anyhow!("No root package"))?;
 
+    if opt.root_only {
+        filter.insert(root.name.clone());
+        return Ok(filter);
+    }
+
     if opt.direct_deps_only {
         filter.insert(root.name.clone());
-
         for package in root.dependencies.iter() {
             filter.insert(package.name.clone());
         }
@@ -73,6 +77,7 @@ pub struct GetDependenciesOpt {
     pub avoid_dev_deps: bool,
     pub avoid_build_deps: bool,
     pub direct_deps_only: bool,
+    pub root_only: bool,
 }
 
 pub fn get_dependencies_from_cargo_lock(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@
 use ansi_term::Colour::Green;
 use ansi_term::Style;
 use anyhow::Result;
-use cargo_license::{get_dependencies_from_cargo_lock, write_json, write_tsv, DependencyDetails};
+use cargo_license::{
+    get_dependencies_from_cargo_lock, write_json, write_tsv, DependencyDetails, GetDependenciesOpt,
+};
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use clap::Parser;
 use std::borrow::Cow;
@@ -150,9 +152,9 @@ struct Opt {
     /// Deactivate default features
     no_default_features: bool,
 
-    #[clap(long = "no-deps")]
+    #[clap(long = "direct-deps-only")]
     /// Output information only about the root package and don't fetch dependencies.
-    no_deps: bool,
+    direct_deps_only: bool,
 
     #[clap(long = "filter-platform", value_name = "TRIPLE")]
     /// Only include resolve dependencies matching the given target-triple.
@@ -203,8 +205,13 @@ fn run() -> Result<()> {
         cmd.other_options(["--filter-platform".into(), triple]);
     }
 
-    let dependencies =
-        get_dependencies_from_cargo_lock(cmd, opt.avoid_dev_deps, opt.avoid_build_deps)?;
+    let get_opts = GetDependenciesOpt {
+        avoid_dev_deps: opt.avoid_dev_deps,
+        avoid_build_deps: opt.avoid_build_deps,
+        direct_deps_only: opt.direct_deps_only,
+    };
+
+    let dependencies = get_dependencies_from_cargo_lock(cmd, get_opts)?;
 
     let enable_color = if let Some(color) = opt.color {
         match color.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,10 @@ struct Opt {
     /// Output information only about the root package and don't fetch dependencies.
     direct_deps_only: bool,
 
+    #[clap(long = "root-only")]
+    /// Output information only about the root package.
+    root_only: bool,
+
     #[clap(long = "filter-platform", value_name = "TRIPLE")]
     /// Only include resolve dependencies matching the given target-triple.
     filter_platform: Option<String>,
@@ -209,6 +213,7 @@ fn run() -> Result<()> {
         avoid_dev_deps: opt.avoid_dev_deps,
         avoid_build_deps: opt.avoid_build_deps,
         direct_deps_only: opt.direct_deps_only,
+        root_only: opt.root_only,
     };
 
     let dependencies = get_dependencies_from_cargo_lock(cmd, get_opts)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,20 +3,22 @@
 
 use ansi_term::Colour::Green;
 use ansi_term::Style;
+use anyhow::Result;
+use cargo_license::{get_dependencies_from_cargo_lock, write_json, write_tsv, DependencyDetails};
+use cargo_metadata::{CargoOpt, MetadataCommand};
 use clap::Parser;
 use std::borrow::Cow;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet};
-use std::io;
 use std::path::PathBuf;
 use std::process::exit;
 
 fn group_by_license_type(
-    dependencies: Vec<cargo_license::DependencyDetails>,
+    dependencies: Vec<DependencyDetails>,
     display_authors: bool,
     enable_color: bool,
 ) {
-    let mut table: BTreeMap<String, Vec<cargo_license::DependencyDetails>> = BTreeMap::new();
+    let mut table: BTreeMap<String, Vec<DependencyDetails>> = BTreeMap::new();
 
     for dependency in dependencies {
         let license = dependency
@@ -60,7 +62,7 @@ fn group_by_license_type(
 }
 
 fn one_license_per_line(
-    dependencies: Vec<cargo_license::DependencyDetails>,
+    dependencies: Vec<DependencyDetails>,
     display_authors: bool,
     enable_color: bool,
 ) {
@@ -95,23 +97,6 @@ fn colored<'a, 'b>(s: &'a str, style: &'b Style, enable_color: bool) -> Cow<'a, 
     } else {
         Cow::Borrowed(s)
     }
-}
-
-fn write_tsv(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
-    let mut wtr = csv::WriterBuilder::new()
-        .delimiter(b'\t')
-        .quote_style(csv::QuoteStyle::Necessary)
-        .from_writer(io::stdout());
-    for dependency in dependencies {
-        wtr.serialize(dependency)?;
-    }
-    wtr.flush()?;
-    Ok(())
-}
-
-fn write_json(dependencies: &[cargo_license::DependencyDetails]) -> cargo_license::Result<()> {
-    println!("{}", serde_json::to_string_pretty(&dependencies)?);
-    Ok(())
 }
 
 #[derive(Debug, Parser)]
@@ -180,7 +165,7 @@ struct Opt {
     color: Option<String>,
 }
 
-fn run() -> cargo_license::Result<()> {
+fn run() -> Result<()> {
     use std::env;
 
     // Drop extra `license` argument when called by `cargo`.
@@ -193,7 +178,7 @@ fn run() -> cargo_license::Result<()> {
     });
 
     let opt = Opt::parse_from(args);
-    let mut cmd = cargo_metadata::MetadataCommand::new();
+    let mut cmd = MetadataCommand::new();
 
     if let Some(path) = &opt.manifest_path {
         cmd.manifest_path(path);
@@ -202,23 +187,20 @@ fn run() -> cargo_license::Result<()> {
         cmd.current_dir(dir);
     }
     if opt.all_features {
-        cmd.features(cargo_metadata::CargoOpt::AllFeatures);
+        cmd.features(CargoOpt::AllFeatures);
     }
     if opt.no_deps {
-        cmd.features(cargo_metadata::CargoOpt::NoDefaultFeatures);
+        cmd.features(CargoOpt::NoDefaultFeatures);
     }
     if let Some(features) = opt.features {
-        cmd.features(cargo_metadata::CargoOpt::SomeFeatures(features));
+        cmd.features(CargoOpt::SomeFeatures(features));
     }
     if let Some(triple) = opt.filter_platform {
         cmd.other_options(["--filter-platform".into(), triple]);
     }
 
-    let dependencies = cargo_license::get_dependencies_from_cargo_lock(
-        cmd,
-        opt.avoid_dev_deps,
-        opt.avoid_build_deps,
-    )?;
+    let dependencies =
+        get_dependencies_from_cargo_lock(cmd, opt.avoid_dev_deps, opt.avoid_build_deps)?;
 
     let enable_color = if let Some(color) = opt.color {
         match color.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,10 @@ struct Opt {
     /// Activate all available features.
     all_features: bool,
 
+    #[clap(long = "no-default-features")]
+    /// Deactivate default features
+    no_default_features: bool,
+
     #[clap(long = "no-deps")]
     /// Output information only about the root package and don't fetch dependencies.
     no_deps: bool,
@@ -189,7 +193,7 @@ fn run() -> Result<()> {
     if opt.all_features {
         cmd.features(CargoOpt::AllFeatures);
     }
-    if opt.no_deps {
+    if opt.no_default_features {
         cmd.features(CargoOpt::NoDefaultFeatures);
     }
     if let Some(features) = opt.features {


### PR DESCRIPTION
(Either merge #53 first or just merge this one)

The reason I opted to create this little freebie opt is because this is what `--no-deps` would've done on `cargo metadata` directly. However the way `cargo metadata` handles ` --no-deps` breaks this crate, therefore we implement a little bit of custom logic to handle this case ourselves.