### PR TITLE
feat: Support for gitlab license scanning report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ semver = "1.0"
 clap = { version =  "3.1.17", features = ["derive"] }
 atty = "0.2"
 anyhow = "1"
+spdx = "0.10.0"
+itertools = "0.10.5"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ OPTIONS:
         --filter-platform <TRIPLE>     Only include resolve dependencies matching the given
                                        target-triple
     -h, --help                         Print help information
+    -g, --gitlab                       Gitlab license scanner output
     -j, --json                         Detailed output as JSON
         --manifest-path <PATH>         Path to Cargo.toml
         --no-default-features          Deactivate default features

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use ansi_term::Colour::Green;
 use ansi_term::Style;
 use anyhow::Result;
 use cargo_license::{
-    get_dependencies_from_cargo_lock, write_json, write_tsv, DependencyDetails, GetDependenciesOpt,
+    get_dependencies_from_cargo_lock, write_gitlab, write_json, write_tsv, DependencyDetails,
+    GetDependenciesOpt,
 };
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use clap::Parser;
@@ -104,7 +105,7 @@ fn one_license_per_line(
     }
 }
 
-fn colored<'a, 'b>(s: &'a str, style: &'b Style, enable_color: bool) -> Cow<'a, str> {
+fn colored<'a>(s: &'a str, style: &Style, enable_color: bool) -> Cow<'a, str> {
     if enable_color {
         Cow::Owned(format!("{}", style.paint(s)))
     } else {
@@ -142,6 +143,10 @@ struct Opt {
     #[clap(short, long)]
     /// Detailed output as JSON.
     json: bool,
+
+    #[clap(short, long)]
+    /// Gitlab license scanner output
+    gitlab: bool,
 
     #[clap(long)]
     /// Exclude development dependencies
@@ -244,6 +249,8 @@ fn run() -> Result<()> {
         write_tsv(&dependencies)?;
     } else if opt.json {
         write_json(&dependencies)?;
+    } else if opt.gitlab {
+        write_gitlab(&dependencies)?;
     } else if opt.do_not_bundle {
         one_license_per_line(dependencies, opt.authors, enable_color);
     } else {
@@ -257,7 +264,7 @@ fn main() {
         Ok(_) => 0,
         Err(e) => {
             for cause in e.chain() {
-                eprintln!("{}", cause);
+                eprintln!("{cause}");
             }
             1
         }


### PR DESCRIPTION
Allows cargo-license to output json file compatible with https://docs.gitlab.com/ee/user/compliance/license_compliance/

(Current Gitlab's tooling for license scanning in Rust projects is broken, with no fix on sight)

Output was tested on private project and works well :)