### PR TITLE
Migrate to clap v4 and remove atty dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ serde_derive = "1"
 serde_json = "1"
 cargo_metadata = "0.15.0"
 semver = "1.0"
-clap = { version =  "3.1.17", features = ["derive"] }
+clap = { version =  "4", features = ["derive"] }
 atty = "0.2"
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ serde_json = "1"
 cargo_metadata = "0.15.0"
 semver = "1.0"
 clap = { version =  "4", features = ["derive"] }
-atty = "0.2"
 anyhow = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use clap::{Parser, ValueEnum};
 use std::borrow::Cow;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::process::exit;
 
@@ -231,7 +232,7 @@ fn run() -> Result<()> {
     let dependencies = get_dependencies_from_cargo_lock(cmd, get_opts)?;
 
     let enable_color = match opt.color {
-        Color::Auto => atty::is(atty::Stream::Stdout),
+        Color::Auto => io::stdin().is_terminal(),
         Color::Always => true,
         Color::Never => false,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use cargo_license::{
     get_dependencies_from_cargo_lock, write_json, write_tsv, DependencyDetails, GetDependenciesOpt,
 };
 use cargo_metadata::{CargoOpt, MetadataCommand};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::borrow::Cow;
 use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::{BTreeMap, BTreeSet};
@@ -175,15 +175,16 @@ struct Opt {
     /// Only include resolve dependencies matching the given target-triple.
     filter_platform: Option<String>,
 
-    #[clap(
-        long = "color",
-        name = "WHEN",
-        possible_value = "auto",
-        possible_value = "always",
-        possible_value = "never"
-    )]
+    #[clap(long = "color", name = "WHEN", value_enum, default_value = "auto")]
     /// Coloring
-    color: Option<String>,
+    color: Color,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum, Debug)]
+enum Color {
+    Auto,
+    Always,
+    Never,
 }
 
 fn run() -> Result<()> {
@@ -229,15 +230,10 @@ fn run() -> Result<()> {
 
     let dependencies = get_dependencies_from_cargo_lock(cmd, get_opts)?;
 
-    let enable_color = if let Some(color) = opt.color {
-        match color.as_ref() {
-            "auto" => atty::is(atty::Stream::Stdout),
-            "always" => true,
-            "never" => false,
-            _ => unreachable!(),
-        }
-    } else {
-        atty::is(atty::Stream::Stdout)
+    let enable_color = match opt.color {
+        Color::Auto => atty::is(atty::Stream::Stdout),
+        Color::Always => true,
+        Color::Never => false,
     };
 
     if opt.tsv {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn one_license_per_line(
     }
 }
 
-fn colored<'a, 'b>(s: &'a str, style: &'b Style, enable_color: bool) -> Cow<'a, str> {
+fn colored<'a>(s: &'a str, style: &Style, enable_color: bool) -> Cow<'a, str> {
     if enable_color {
         Cow::Owned(format!("{}", style.paint(s)))
     } else {
@@ -251,10 +251,10 @@ fn run() -> Result<()> {
 
 fn main() {
     exit(match run() {
-        Ok(_) => 0,
+        Ok(()) => 0,
         Err(e) => {
             for cause in e.chain() {
-                eprintln!("{}", cause);
+                eprintln!("{cause}");
             }
             1
         }


### PR DESCRIPTION
This PR updates the clap dependency and removed the [unmainted](https://rustsec.org/advisories/RUSTSEC-2021-0145) `atty` dependency.

`atty` is replaced with the use of `std::io::IsTerminal`, stable since `rust` 1.70.