### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"
 edition = "2021"
+rust-version = "1.70"
 
 [dependencies]
 getopts = "0.2.21"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/onur/cargo-license/workflows/CI/badge.svg)](https://github.com/onur/cargo-license/actions?workflow=CI)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/onur/cargo-license/master/LICENSE)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.34-red)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.70-red)
 
 A cargo subcommand to see license of dependencies.
 


### PR DESCRIPTION
This PR bumps MSRV to 1.70.
This is because `std::io::IsTerminal` and clap v4 require Rust 1.70.

Related: #64 