### PR TITLE
fix: export the types used in public functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-license"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-license"
 description = "Cargo subcommand to see license of dependencies"
 authors = ["Onur Aslan <onur@onur.im>"]
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/onur/cargo-license"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub use cargo_metadata::MetadataCommand;
+
 use anyhow::Result;
 use cargo_metadata::{
-    CrateType, DepKindInfo, DependencyKind, Metadata, MetadataCommand, Node, NodeDep, Package,
+    CrateType, DepKindInfo, DependencyKind, Metadata, Node, NodeDep, Package,
     PackageId,
 };
 use itertools::Itertools;


### PR DESCRIPTION
This is so the correct version of `MetadataCommand` can be used when calling the `get_dependencies_from_cargo_lock` function.

Right now projects need to directly depend on both this crate and the [cargo_metadata](https://crates.io/crates/cargo_metadata) crate to use the types and call the function. The cargo_metadata crate had been recently updated.